### PR TITLE
support xgboost

### DIFF
--- a/examples/housing/configs/xgboost_config.pb
+++ b/examples/housing/configs/xgboost_config.pb
@@ -1,0 +1,43 @@
+# proto-file: tabml/protos/pipeline.proto
+# proto-message: Config
+config_name: "xgboost"
+data_loader {
+    cls_name: "tabml.data_loaders.BaseDataLoader"
+    feature_manager_config_path: "configs/feature_config.pb"
+
+    features_to_model: "scaled_housing_median_age"
+    features_to_model: "median_income"
+    features_to_model: "scaled_clean_total_rooms"
+    features_to_model: "scaled_clean_total_bedrooms"
+    features_to_model: "scaled_clean_population"
+    features_to_model: "bucketized_latitude"
+    features_to_model: "bucketized_longitude"
+    features_to_model: "hashed_bucketized_latitude_X_bucketized_longitude"
+    features_to_model: "encoded_ocean_proximity"
+
+    label_col: "log10_median_house_value"
+
+    train_filters: "is_train"
+
+    validation_filters: "not is_train"
+
+    submission_filters: "not is_train"
+}
+model_wrapper {
+    # use a custom lgbm model_wrapper
+    xgboost_params {
+        learning_rate: 0.1
+        n_estimators: 200
+        objective: "reg:squarederror"
+        eval_metric: "rmse"
+    }
+}
+trainer {
+    cls_name: "tabml.trainers.XGBoostTrainer"
+}
+model_analysis {
+    metrics: "smape"
+    metrics: "rmse"
+    by_features: "ocean_proximity"
+    by_label: "median_house_value"
+}

--- a/examples/housing/pipelines.py
+++ b/examples/housing/pipelines.py
@@ -1,4 +1,4 @@
-from tabml.model_wrappers import LgbmRegressorModelWrapper
+from tabml.model_wrappers import LgbmRegressorModelWrapper, XGBoostRegressorModelWrapper
 from tabml.pipelines import BasePipeline
 
 
@@ -11,10 +11,27 @@ class CustomLgbmRegressorModelWrapperLog10(LgbmRegressorModelWrapper):
         return 10 ** self.model.predict(data)
 
 
+class CustomXGBoostRegressorModelWrapperLog10(XGBoostRegressorModelWrapper):
+    """Custom Model Wrapper for prediction log10 of median house value."""
+
+    def predict(self, data):
+        # In prediction, the model should return the outputs that are in the same
+        # space with the true label.
+        return 10 ** self.model.predict(data)
+
+
 def train_lgbm():
     path_to_config = "configs/lgbm_config.pb"
     pipeline = BasePipeline(
         path_to_config, custom_model_wrapper=CustomLgbmRegressorModelWrapperLog10
+    )
+    pipeline.run()
+
+
+def train_xgboost():
+    path_to_config = "configs/xgboost_config.pb"
+    pipeline = BasePipeline(
+        path_to_config, custom_model_wrapper=CustomXGBoostRegressorModelWrapperLog10
     )
     pipeline.run()
 

--- a/examples/housing/test_housing.py
+++ b/examples/housing/test_housing.py
@@ -4,6 +4,15 @@ from . import feature_manager, pipelines
 
 
 @change_working_dir_pytest
-def test_full_pipeline():
+def test_feature_manager():
     feature_manager.run()
+
+
+@change_working_dir_pytest
+def test_full_pipeline_lgbm():
     pipelines.train_lgbm()
+
+
+@change_working_dir_pytest
+def test_full_pipeline_xgboost():
+    pipelines.train_xgboost()

--- a/examples/titanic/configs/xgboost_config.pb
+++ b/examples/titanic/configs/xgboost_config.pb
@@ -1,0 +1,38 @@
+config_name: "xgboost"
+data_loader {
+  cls_name: "tabml.data_loaders.BaseDataLoader"
+  feature_manager_config_path: "configs/feature_config.pb"
+
+  features_to_model: "coded_sex"
+  features_to_model: "imputed_age"
+  features_to_model: "bucketized_age"
+  features_to_model: "min_max_scaled_age"
+  features_to_model: "coded_pclass"
+  features_to_model: "coded_title"
+
+  label_col: "survived"
+
+  train_filters: "is_train"
+  validation_filters: "not is_train"
+  validation_filters: "passenger_id <= 891"
+  submission_filters: "passenger_id > 891"
+}
+
+model_wrapper {
+  cls_name: "tabml.model_wrappers.XGBoostClassifierModelWrapper"
+  xgboost_params {
+    n_estimators: 100
+    objective: "binary:logistic"
+    eval_metric: "auc"
+  }
+}
+trainer {
+  cls_name: "tabml.trainers.XGBoostTrainer"
+}
+model_analysis {
+  metrics: "accuracy_score"
+  metrics: "roc_auc"
+  metrics: "max_f1"
+  by_features: "sex"
+  by_features: "pclass"
+}

--- a/examples/titanic/pipelines.py
+++ b/examples/titanic/pipelines.py
@@ -7,5 +7,11 @@ def train_lgbm():
     pipeline.run()
 
 
+def train_xgboost():
+    path_to_config = "configs/xgboost_config.pb"
+    pipeline = BasePipeline(path_to_config)
+    pipeline.run()
+
+
 if __name__ == "__main__":
     train_lgbm()

--- a/examples/titanic/test_titanic.py
+++ b/examples/titanic/test_titanic.py
@@ -13,8 +13,13 @@ def test_run():
 
 
 @change_working_dir_pytest
-def test_full_pipeline():
+def test_full_pipeline_lgbm():
     pipelines.train_lgbm()
+
+
+@change_working_dir_pytest
+def test_full_pipeline_xgboost():
+    pipelines.train_xgboost()
 
 
 @change_working_dir_pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ scikit-learn==0.24.2
 scipy==1.6.2
 # pytorch-tabnet==3.1.1
 termgraph==0.4.2
-# xgboost==1.1.1
+xgboost==1.4.2

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "scikit-learn>=0.24.2",
         "scipy>=1.6.2",
         "termgraph>=0.4.2",
+        "xgboost>=1.4.2",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tabml/protos/model_wrappers.proto
+++ b/tabml/protos/model_wrappers.proto
@@ -28,7 +28,7 @@ message ModelWrapperLgbmParams {
 }
 
 // XGBoost parameters in https://xgboost.readthedocs.io/en/latest/parameter.html
-// Next id: 13
+// Next id: 14
 message ModelWrapperXgboostParams {
     optional bool use_gpu = 1;
     optional int32 max_depth = 2;
@@ -42,6 +42,7 @@ message ModelWrapperXgboostParams {
     optional float learning_rate = 10;
     optional float min_child_weight = 11;
     optional int32 seed = 12 [default = 42];
+    optional string eval_metric = 13;
 }
 
 message ModelWrapper {

--- a/tabml/protos/model_wrappers_pb2.py
+++ b/tabml/protos/model_wrappers_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto2',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n!tabml/protos/model_wrappers.proto\x12\x0ctabml.protos\"\xcb\x03\n\x16ModelWrapperLgbmParams\x12\x15\n\rlearning_rate\x18\x01 \x01(\x02\x12\x14\n\x0cn_estimators\x18\x02 \x01(\x05\x12\x12\n\nnum_leaves\x18\x03 \x01(\x05\x12\x11\n\tmax_depth\x18\x04 \x01(\x05\x12\x1d\n\tobjective\x18\x05 \x01(\t:\nregression\x12\x18\n\x10\x63olsample_bytree\x18\x06 \x01(\x02\x12\x11\n\tsubsample\x18\x07 \x01(\x02\x12\x11\n\treg_alpha\x18\x08 \x01(\x02\x12\x16\n\x0emin_split_gain\x18\t \x01(\x02\x12\x12\n\nreg_lambda\x18\n \x01(\x02\x12\x18\n\x10min_child_weight\x18\x0b \x01(\x02\x12\x19\n\x11min_child_samples\x18\x0c \x01(\x05\x12\x18\n\x0crandom_state\x18\r \x01(\x05:\x02\x34\x32\x12\x16\n\x0esubsample_freq\x18\x0e \x01(\x05\x12\x19\n\x11subsample_for_bin\x18\x0f \x01(\x05\x12\x15\n\rboosting_type\x18\x10 \x01(\t\x12\x0e\n\x06metric\x18\x11 \x01(\t\x12\x18\n\x10scale_pos_weight\x18\x12 \x01(\x05\x12\x0f\n\x07max_bin\x18\x13 \x01(\x05\"\xa0\x02\n\x19ModelWrapperXgboostParams\x12\x0f\n\x07use_gpu\x18\x01 \x01(\x08\x12\x11\n\tmax_depth\x18\x02 \x01(\x05\x12\x14\n\x0cn_estimators\x18\x03 \x01(\x05\x12\r\n\x05gamma\x18\x04 \x01(\x02\x12#\n\tobjective\x18\x05 \x01(\t:\x10reg:squarederror\x12\x18\n\x10\x63olsample_bytree\x18\x06 \x01(\x02\x12\x11\n\tsubsample\x18\x07 \x01(\x02\x12\x11\n\treg_alpha\x18\x08 \x01(\x02\x12\x12\n\nreg_lambda\x18\t \x01(\x02\x12\x15\n\rlearning_rate\x18\n \x01(\x02\x12\x18\n\x10min_child_weight\x18\x0b \x01(\x02\x12\x10\n\x04seed\x18\x0c \x01(\x05:\x02\x34\x32\"\xaa\x01\n\x0cModelWrapper\x12\x10\n\x08\x63ls_name\x18\x01 \x02(\t\x12;\n\x0blgbm_params\x18\x02 \x01(\x0b\x32$.tabml.protos.ModelWrapperLgbmParamsH\x00\x12\x41\n\x0exgboost_params\x18\x03 \x01(\x0b\x32\'.tabml.protos.ModelWrapperXgboostParamsH\x00\x42\x08\n\x06params'
+  serialized_pb=b'\n!tabml/protos/model_wrappers.proto\x12\x0ctabml.protos\"\xcb\x03\n\x16ModelWrapperLgbmParams\x12\x15\n\rlearning_rate\x18\x01 \x01(\x02\x12\x14\n\x0cn_estimators\x18\x02 \x01(\x05\x12\x12\n\nnum_leaves\x18\x03 \x01(\x05\x12\x11\n\tmax_depth\x18\x04 \x01(\x05\x12\x1d\n\tobjective\x18\x05 \x01(\t:\nregression\x12\x18\n\x10\x63olsample_bytree\x18\x06 \x01(\x02\x12\x11\n\tsubsample\x18\x07 \x01(\x02\x12\x11\n\treg_alpha\x18\x08 \x01(\x02\x12\x16\n\x0emin_split_gain\x18\t \x01(\x02\x12\x12\n\nreg_lambda\x18\n \x01(\x02\x12\x18\n\x10min_child_weight\x18\x0b \x01(\x02\x12\x19\n\x11min_child_samples\x18\x0c \x01(\x05\x12\x18\n\x0crandom_state\x18\r \x01(\x05:\x02\x34\x32\x12\x16\n\x0esubsample_freq\x18\x0e \x01(\x05\x12\x19\n\x11subsample_for_bin\x18\x0f \x01(\x05\x12\x15\n\rboosting_type\x18\x10 \x01(\t\x12\x0e\n\x06metric\x18\x11 \x01(\t\x12\x18\n\x10scale_pos_weight\x18\x12 \x01(\x05\x12\x0f\n\x07max_bin\x18\x13 \x01(\x05\"\xb5\x02\n\x19ModelWrapperXgboostParams\x12\x0f\n\x07use_gpu\x18\x01 \x01(\x08\x12\x11\n\tmax_depth\x18\x02 \x01(\x05\x12\x14\n\x0cn_estimators\x18\x03 \x01(\x05\x12\r\n\x05gamma\x18\x04 \x01(\x02\x12#\n\tobjective\x18\x05 \x01(\t:\x10reg:squarederror\x12\x18\n\x10\x63olsample_bytree\x18\x06 \x01(\x02\x12\x11\n\tsubsample\x18\x07 \x01(\x02\x12\x11\n\treg_alpha\x18\x08 \x01(\x02\x12\x12\n\nreg_lambda\x18\t \x01(\x02\x12\x15\n\rlearning_rate\x18\n \x01(\x02\x12\x18\n\x10min_child_weight\x18\x0b \x01(\x02\x12\x10\n\x04seed\x18\x0c \x01(\x05:\x02\x34\x32\x12\x13\n\x0b\x65val_metric\x18\r \x01(\t\"\xaa\x01\n\x0cModelWrapper\x12\x10\n\x08\x63ls_name\x18\x01 \x02(\t\x12;\n\x0blgbm_params\x18\x02 \x01(\x0b\x32$.tabml.protos.ModelWrapperLgbmParamsH\x00\x12\x41\n\x0exgboost_params\x18\x03 \x01(\x0b\x32\'.tabml.protos.ModelWrapperXgboostParamsH\x00\x42\x08\n\x06params'
 )
 
 
@@ -275,6 +275,13 @@ _MODELWRAPPERXGBOOSTPARAMS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='eval_metric', full_name='tabml.protos.ModelWrapperXgboostParams.eval_metric', index=12,
+      number=13, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -288,7 +295,7 @@ _MODELWRAPPERXGBOOSTPARAMS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=514,
-  serialized_end=802,
+  serialized_end=823,
 )
 
 
@@ -338,8 +345,8 @@ _MODELWRAPPER = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=805,
-  serialized_end=975,
+  serialized_start=826,
+  serialized_end=996,
 )
 
 _MODELWRAPPER.fields_by_name['lgbm_params'].message_type = _MODELWRAPPERLGBMPARAMS

--- a/tabml/trainers.py
+++ b/tabml/trainers.py
@@ -70,3 +70,13 @@ class LgbmTrainer(BaseBoostingTrainer):
             **pb_to_dict(self.config.trainer.lgbm_params),
         }
         return fit_params
+
+
+class XGBoostTrainer(BaseBoostingTrainer):
+    def _get_fit_params(self, train_data, val_data):
+        fit_params = {
+            "eval_set": [train_data, val_data],
+            "callbacks": [boosting_logger_eval(model="xgboost")],
+            **pb_to_dict(self.config.trainer.xgboost_params),
+        }
+        return fit_params

--- a/tabml/utils/logger.py
+++ b/tabml/utils/logger.py
@@ -19,6 +19,16 @@ def lgbm_format_eval_result(value, show_stdv=True):
     raise ValueError("Wrong metric value")
 
 
+def xgboost_format_eval_result(value, show_stdv=True):
+    if len(value) == 2:
+        return "{0}:{1:.5f}".format(value[0], value[1])
+    if len(value) == 3:
+        if show_stdv:
+            return "{0}:{1:.5f}+{2:.5f}".format(value[0], value[1], value[2])
+        return "{0}:{1:.5f}".format(value[0], value[1])
+    raise ValueError("wrong metric value")
+
+
 def boosting_logger_eval(model: str, period: int = 1, show_stdv: bool = True):
     """Creates a callback that prints the evaluation results for lgbm.
 
@@ -37,6 +47,8 @@ def boosting_logger_eval(model: str, period: int = 1, show_stdv: bool = True):
     """
     if model == "lgbm":
         format_result_func = lgbm_format_eval_result
+    elif model == "xgboost":
+        format_result_func = xgboost_format_eval_result
     else:
         raise TypeError(f"Unexpected model {model}. Only accept lgbm or xgb model.")
 


### PR DESCRIPTION
ref: https://xgboost.readthedocs.io/en/latest/install.html

NOTE: xgboost does not support categorical features, so the encoding labels for categorical features need to be engineered carefully.

- [x] add tests for xgboost classification (titanic)
- [ ] add tests for xgboost regression (housing)