### PR TITLE
Support prediction features

### DIFF
--- a/tabml/schemas/feature_config.py
+++ b/tabml/schemas/feature_config.py
@@ -11,7 +11,7 @@ class DType(Enum):
     INT64 = "INT64"
     STRING = "STRING"
     DOUBLE = "DOUBLE"
-    # data and time types https://docs.python.org/3/library/datetime.html
+    # Date and time types https://docs.python.org/3/library/datetime.html
     DATE = "DATE"
     TIME = "TIME"
     DATETIME = "DATETIME"
@@ -23,22 +23,21 @@ class BaseFeature(pydantic.BaseModel):
 
 
 class TransformingFeature(pydantic.BaseModel):
-    # feature name, need to be unique in the FeatureConfig.
     name: str
 
-    # index of the feature in the dataset. Indexes should be unique, positive and
+    # The index of the feature in the dataset. Indexes should be unique, positive and
     # monotonically increasing. Indexes are used to determine the feature order in the
     # whole dataset. Base features are added to the dataset first, then
-    # transforming_features in the ascending order of indexes.
+    # transforming_features and prediction_features in the ascending order of indexes.
     index: int
 
-    # dependencies is a list of features that are required to compute this feature.
+    dtype: DType
+
+    # Dependencies is a list of features that are required to compute this feature.
     # This field will be used when users want to re-compute one feature. All features
     # depending on this re-computed feature are also required to be updated.
     # NOTE on terminology: If feature "a" depends on feature "b" then we call "b" is
     # one of dependencies of "a", and "a" is a dependent of "b".
-    dtype: DType
-
     dependencies: List[str] = []
 
 
@@ -56,23 +55,23 @@ class PredictionFeature(pydantic.BaseModel):
 
 
 class FeatureConfig(pydantic.BaseModel):
-    # directory of raw data files
+    # Directory of raw data files.
     raw_data_dir: str
 
-    # name of the dataframe to store features, also the name of the csv dataframe file.
+    # Name of the dataframe to store features, also the name of the csv dataframe file.
     # The csv file path will be raw_data_dir / features / dataset_name + ".csv".
     dataset_name: str
 
-    # base_features are features that are not dependent on any features.
+    # Base features are features that are not dependent on any features.
     # These features are usually created right after the data cleaning step.
     base_features: List[BaseFeature]
 
-    # transforming_features are those dependent on base features and/or other
+    # Transforming features are those dependent on base features and/or other
     # transforming features. Note that the term "feature" here only apply to columns in
     # the final dataframe saved in dataset_name. Data taken from additional dataframes
     # is not considered as features.
     transforming_features: List[TransformingFeature]
 
-    # prediction features are those computed as predictions of another models. These
+    # Prediction features are those computed as predictions of another models. These
     # are useful for stacking models.
     prediction_features: List[PredictionFeature]

--- a/tabml/schemas/feature_config.py
+++ b/tabml/schemas/feature_config.py
@@ -42,6 +42,19 @@ class TransformingFeature(pydantic.BaseModel):
     dependencies: List[str] = []
 
 
+class PredictionFeature(pydantic.BaseModel):
+    # Features that are predicted by a tabml model. These features could be used in
+    # stacking models.
+    name: str
+    index: int
+    dtype: DType
+    model_path: str
+
+    # The list of dependencies can be found in
+    # pipeline_config.data_loader.features_to_model.
+    pipeline_config_path: str
+
+
 class FeatureConfig(pydantic.BaseModel):
     # directory of raw data files
     raw_data_dir: str
@@ -59,3 +72,7 @@ class FeatureConfig(pydantic.BaseModel):
     # the final dataframe saved in dataset_name. Data taken from additional dataframes
     # is not considered as features.
     transforming_features: List[TransformingFeature]
+
+    # prediction features are those computed as predictions of another models. These
+    # are useful for stacking models.
+    prediction_features: List[PredictionFeature]


### PR DESCRIPTION
Prediction features are computed by other (tabml) models. These features could be used to train a [Stacking Model](https://machinelearningmastery.com/stacking-ensemble-machine-learning-with-python/).