### PR TITLE
Allow unordered indexing in feature configs

### DIFF
--- a/tabml/feature_config_helper.py
+++ b/tabml/feature_config_helper.py
@@ -1,6 +1,7 @@
 import copy
 from typing import Dict, List, Union
 
+from tabml import schemas
 from tabml.config_helpers import parse_feature_config
 from tabml.schemas.feature_config import BaseFeature, DType, TransformingFeature
 from tabml.utils.utils import check_uniqueness
@@ -54,7 +55,7 @@ class FeatureConfigHelper:
         self.dataset_name = self.config.dataset_name
         self.base_features = self.config.base_features
         self.base_feature_names = self._get_base_feature_names()
-        self.transforming_features = self.config.transforming_features
+        self.transforming_features = self._get_sorted_transforming_features()
         self.transforming_feature_names = self._get_transforming_feature_names()
         self.all_feature_names = self._get_all_feature_names()
         self._validate()
@@ -63,6 +64,11 @@ class FeatureConfigHelper:
 
     def _get_base_feature_names(self):
         return [feature.name for feature in self.config.base_features]
+
+    def _get_sorted_transforming_features(
+        self,
+    ) -> List[schemas.feature_config.TransformingFeature]:
+        return sorted(self.config.transforming_features, key=lambda x: x.index)
 
     def _get_transforming_feature_names(self):
         return [

--- a/tabml/tests/test_feature_config_helper.py
+++ b/tabml/tests/test_feature_config_helper.py
@@ -21,6 +21,11 @@ class TestFeatureConfigHelper:
                 dtype: STRING
                 dependencies:
                   - "a"
+              - name: "e"
+                index: 4
+                dtype: STRING
+                dependencies:
+                  - "c"
               - name: "c"
                 index: 2
                 dtype: STRING
@@ -32,11 +37,6 @@ class TestFeatureConfigHelper:
                 dtype: STRING
                 dependencies:
                   - "a"
-              - name: "e"
-                index: 4
-                dtype: STRING
-                dependencies:
-                  - "c"
         """
         config_path = tmp_path / "feature_config_str.yaml"
         write_str_to_file(feature_config_str, config_path)


### PR DESCRIPTION
as long as dependencies have smaller indexes.


This is useful for later use case when we'd like to add prediction features. This allow a transforming feature depending on a prediction feature to have a higher index although it appears first in the transforming_features group.