### PR TITLE
model analysis: separate dataset size for metric computation and explainer computation

### DIFF
--- a/tabml/examples/titanic/pipelines.py
+++ b/tabml/examples/titanic/pipelines.py
@@ -1,8 +1,11 @@
 from tabml.pipelines import BasePipeline
+from typing import Union
+from pathlib import Path
+from tabml.schemas.pipeline_config import PipelineConfig
 
 
-def run(pipeline_config_path: str):
-    pipeline = BasePipeline(config=pipeline_config_path)
+def run(config: Union[str, Path, PipelineConfig]):
+    pipeline = BasePipeline(config=config)
     pipeline.run()
 
 

--- a/tabml/examples/titanic/test_titanic.py
+++ b/tabml/examples/titanic/test_titanic.py
@@ -39,8 +39,8 @@ RAW_DATA_SAMPLES = [
 def create_test_config(config_path: Union[str, Path]) -> PipelineConfig:
     config = parse_pipeline_config(config_path)
     config.model_wrapper.model_params["n_estimators"] = 10
-    config.model_analysis.explainer_train_size = 0.1
-    config.model_analysis.metric_train_size = 100
+    config.model_analysis.explainer_train_size = 50
+    config.model_analysis.metric_train_size = 10
     return config
 
 
@@ -74,6 +74,7 @@ def test_full_pipeline_lgbm():
 def test_full_pipeline_xgboost():
     pipeline_config_path = "./configs/xgboost_config.yaml"
     config = create_test_config(pipeline_config_path)
+    config.model_analysis.show_feature_importance = False
     pipelines.run(config)
     _test_inference(pipeline_config_path)
 
@@ -82,6 +83,7 @@ def test_full_pipeline_xgboost():
 def test_full_pipeline_catboost():
     pipeline_config_path = "./configs/catboost_config.yaml"
     config = create_test_config(pipeline_config_path)
+    config.model_analysis.show_feature_importance = False
     pipelines.run(config)
     _test_inference(pipeline_config_path)
 
@@ -90,5 +92,6 @@ def test_full_pipeline_catboost():
 def test_full_pipeline_randomforest():
     pipeline_config_path = "./configs/rf_config.yaml"
     config = create_test_config(pipeline_config_path)
+    config.model_analysis.show_feature_importance = False
     pipelines.run(config)
     _test_inference(pipeline_config_path)

--- a/tabml/examples/titanic/test_titanic.py
+++ b/tabml/examples/titanic/test_titanic.py
@@ -3,6 +3,9 @@ from tabml.examples.titanic import feature_manager, pipelines
 from tabml.experiment_manager import ExperimentManager
 from tabml.inference import ModelInference
 from tabml.utils.utils import change_working_dir_pytest
+from tabml.schemas.pipeline_config import PipelineConfig
+from typing import Union
+from pathlib import Path
 
 RAW_DATA_SAMPLES = [
     {
@@ -33,6 +36,14 @@ RAW_DATA_SAMPLES = [
 ]
 
 
+def create_test_config(config_path: Union[str, Path]) -> PipelineConfig:
+    config = parse_pipeline_config(config_path)
+    config.model_wrapper.model_params["n_estimators"] = 10
+    config.model_analysis.explainer_train_size = 0.1
+    config.model_analysis.metric_train_size = 100
+    return config
+
+
 def _test_inference(config_path):
     config = parse_pipeline_config(yaml_path=config_path)
     pipeline_bundle_path = (
@@ -53,24 +64,31 @@ def test_run():
 
 @change_working_dir_pytest
 def test_full_pipeline_lgbm():
-    pipelines.train_lgbm()
-    _test_inference("./configs/lgbm_config.yaml")
+    pipeline_config_path = "configs/lgbm_config.yaml"
+    config = create_test_config(pipeline_config_path)
+    pipelines.run(config)
+    _test_inference(pipeline_config_path)
 
 
 @change_working_dir_pytest
 def test_full_pipeline_xgboost():
-    pipelines.train_xgboost()
-    _test_inference("./configs/xgboost_config.yaml")
+    pipeline_config_path = "./configs/xgboost_config.yaml"
+    config = create_test_config(pipeline_config_path)
+    pipelines.run(config)
+    _test_inference(pipeline_config_path)
 
 
 @change_working_dir_pytest
 def test_full_pipeline_catboost():
-    pipelines.train_catboost()
-    _test_inference("./configs/catboost_config.yaml")
+    pipeline_config_path = "./configs/catboost_config.yaml"
+    config = create_test_config(pipeline_config_path)
+    pipelines.run(config)
+    _test_inference(pipeline_config_path)
 
 
 @change_working_dir_pytest
 def test_full_pipeline_randomforest():
-    config_path = "./configs/rf_config.yaml"
-    pipelines.run(config_path)
-    _test_inference(config_path)
+    pipeline_config_path = "./configs/rf_config.yaml"
+    config = create_test_config(pipeline_config_path)
+    pipelines.run(config)
+    _test_inference(pipeline_config_path)

--- a/tabml/schemas/pipeline_config.py
+++ b/tabml/schemas/pipeline_config.py
@@ -38,6 +38,13 @@ class ModelAnalysis(pydantic.BaseModel):
     # for backward compatibility.
     show_feature_importance: bool = True
 
+    # How many datapoints used for running explainer.
+    # Only used when show_feature_importance = True
+    # int: number of datapoints
+    # float: must be a number in (0, 1]
+    # None: all datapoints
+    explainer_train_size: Union[int, float, None] = None
+
     # list of features for analysis
     by_features: List[str] = []
 
@@ -46,10 +53,23 @@ class ModelAnalysis(pydantic.BaseModel):
     # original label.
     by_label: Union[str, None] = None
 
-    # To avoid expensive computations, e.g. computing SHAP values or inference,
-    # a subset of training data could be used instead. This field specifies size
-    # of that subset.
-    training_size: Union[int, None] = None
+    # To avoid expensive computations, a subset of training data could be used instead.
+    # This field specifies the subset size. Usage is similar to explainer_train_size.
+    metric_train_size: Union[int, float, None] = None
+
+    @pydantic.validator("explainer_train_size")
+    def validate_float_explainer_train_size(cls, v):
+        if isinstance(v, float) and (v <= 0 or v >= 1):
+            raise ValueError(
+                "When explainer_train_size is a float, it must be in (0, 1)."
+            )
+        return v.title()
+
+    @pydantic.validator("metric_train_size")
+    def validate_float_metric_train_size(cls, v):
+        if isinstance(v, float) and (v <= 0 or v >= 1):
+            raise ValueError("When metric_train_size is a float, it must be in (0, 1).")
+        return v.title()
 
 
 class PipelineConfig(pydantic.BaseModel):


### PR DESCRIPTION
- schemas/pipeline config: add float type for training_size and validator when it's a float
- model analysis: separate dataset size for explainer and regular metric computation
